### PR TITLE
Load json for using json-read-from-string

### DIFF
--- a/jenkins.el
+++ b/jenkins.el
@@ -33,6 +33,7 @@
 
 (require 'dash)
 (require 'cl-lib)
+(require 'json)
 
 (defconst jenkins-buffer-name
   "*jenkins-status*"


### PR DESCRIPTION
Because it is not an autoload-ed function.
