### PR TITLE
RFC: View console output of a build

### DIFF
--- a/jenkins.el
+++ b/jenkins.el
@@ -335,7 +335,7 @@
 (defun jenkins-get-console-output (jobname build)
   "Show the console output for the current job"
   (let ((url-request-extra-headers (jenkins--get-auth-headers))
-        (console-buffer (get-buffer-create (format "*jenkins-console-%s*-%s" jobname build)))
+        (console-buffer (get-buffer-create (format "*jenkins-console-%s-%s*" jobname build)))
         (url (format "%sjob/%s/%s/consoleText" (get-jenkins-url) jobname build)))
     (with-current-buffer console-buffer
       (erase-buffer)

--- a/jenkins.el
+++ b/jenkins.el
@@ -52,7 +52,7 @@
     (define-key keymap (kbd "1") 'jenkins-job-details-toggle)
     (define-key keymap (kbd "b") 'jenkins--call-build-job-from-job-screen)
     (define-key keymap (kbd "v") 'jenkins--visit-job-from-job-screen)
-    (define-key keymap (kbd "c") 'jenkins--show-console-output-from-job-screen)
+    (define-key keymap (kbd "$") 'jenkins--show-console-output-from-job-screen)
     keymap)
   "Jenkins jobs status mode keymap.")
 
@@ -329,8 +329,6 @@
   "Open job's webpage using JOBNAME."
   (interactive)
   (browse-url (format "%s/job/%s/" (get-jenkins-url) jobname)))
-
-(jenkins-get-console-output "portal_master" 11)
 
 (defun jenkins-get-console-output (jobname build)
   "Show the console output for the current job"

--- a/jenkins.el
+++ b/jenkins.el
@@ -52,6 +52,7 @@
     (define-key keymap (kbd "1") 'jenkins-job-details-toggle)
     (define-key keymap (kbd "b") 'jenkins--call-build-job-from-job-screen)
     (define-key keymap (kbd "v") 'jenkins--visit-job-from-job-screen)
+    (define-key keymap (kbd "c") 'jenkins--show-console-output-from-job-screen)
     keymap)
   "Jenkins jobs status mode keymap.")
 
@@ -150,7 +151,7 @@
   (format (concat
            "%sjob/%s/"
            "api/json?depth=1&tree=builds"
-           "[id,timestamp,result,url,building,"
+           "[number,timestamp,result,url,building,"
            "culprits[fullName]]")
           (get-jenkins-url) jobname))
 
@@ -288,7 +289,7 @@
                         (cdr (assoc attr item)))
               (convert-item (item)
                   (list
-                   (string-to-number (retrieve 'id item))
+                   (retrieve 'number item)
                    :author (let ((culprits (cdr (assoc 'culprits values))))
                              (if (> (length culprits) 0)
                                  (cdar (aref culprits 0)) "---"))
@@ -329,6 +330,19 @@
   (interactive)
   (browse-url (format "%s/job/%s/" (get-jenkins-url) jobname)))
 
+(jenkins-get-console-output "portal_master" 11)
+
+(defun jenkins-get-console-output (jobname build)
+  "Show the console output for the current job"
+  (let ((url-request-extra-headers (jenkins--get-auth-headers))
+        (console-buffer (get-buffer-create (format "*jenkins-console-%s*-%s" jobname build)))
+        (url (format "%sjob/%s/%s/consoleText" (get-jenkins-url) jobname build)))
+    (with-current-buffer console-buffer
+      (erase-buffer)
+      (with-current-buffer (url-retrieve-synchronously url)
+        (copy-to-buffer console-buffer (point-min) (point-max))))
+    (pop-to-buffer console-buffer)))
+
 (defun jenkins--visit-job-from-main-screen ()
   "Open browser for current job."
   (interactive)
@@ -338,6 +352,17 @@
   "Open browser for current job."
   (interactive)
   (jenkins-visit-job jenkins-local-jobname))
+
+(defun jenkins--show-console-output-from-job-screen ()
+  "Show the console output for the currently selected build"
+  (interactive)
+  (let* ((props (text-properties-at (point) (current-buffer)))
+         (jenkins-tag (member 'jenkins-build-number props))
+         (build-number (and jenkins-tag
+                          (cadr jenkins-tag))))
+    (if build-number
+        (jenkins-get-console-output jenkins-local-jobname build-number)
+      (error "Not on a Jenkins build line"))))
 
 ;; emacs major mode funcs and variables
 (define-derived-mode jenkins-mode tabulated-list-mode "Jenkins"
@@ -434,6 +459,8 @@
                             (plist-get (cdr it) :author)
                             (plist-get (cdr it) :timestring)
                             )
+                    'jenkins-build-number
+                    (car it)
                     'face
                     (jenkins--get-proper-face-for-result
                      (plist-get (cdr it) :result)


### PR DESCRIPTION
Give the user the ability to see the console output from a build.

On my Jenkins server, id was not returning anything sane, and I had to resort to a build number.

I'm not sure if the console buffer should be named differently either.

Thanks!  I <3 jenkins.el
