### PR TITLE
Explicitly get the builds key from the job JSON

### DIFF
--- a/jenkins.el
+++ b/jenkins.el
@@ -305,7 +305,7 @@
     (let* (
          (job-url (jenkins-job-url jobname))
          (raw-data (jenkins--retrieve-page-as-json job-url))
-         (builds (-map #'convert-item (vector-take 25 (cdar raw-data))))
+         (builds (-map #'convert-item (vector-take 25 (alist-get 'builds raw-data))))
          (latestSuccessful
           (caar (--filter (equal (plist-get (cdr it) :result) "SUCCESS") builds)))
          (latestFailed


### PR DESCRIPTION
Newer version of Jenkins include "_class" at the top level of the job
JSON:

    $ curl -g 'http://jenkins.example.com/job/foobar/api/json?depth=1&tree=builds[number,timestamp,result,url,building,culprits[fullName]]&pretty=true'
    {
      "_class": "hudson.model.FreeStyleProject",
      "builds": [
        {
          "_class": "hudson.model.FreeStyleBuild",
          "building": false,
          "number": 8622,
          "result": "SUCCESS",
          "timestamp": 1499923920765,
          "url": "http://jenkins.example.com/job/foobar/8622/",
          "culprits": []
        },
       ...

This means that `cdar` does not return the correct part of the
JSON. Instead, explicitly access the key we want.