### PR TITLE
Enforce a trailing slash in the Jenkins URL

### DIFF
--- a/jenkins.el
+++ b/jenkins.el
@@ -114,7 +114,11 @@
 
 (defun get-jenkins-url ()
   "This function is for backward compatibility."
-  (or jenkins-url jenkins-hostname))
+  (let ((url (or jenkins-url jenkins-hostname)))
+    ;; Ensure URL ends with /.
+    (if (string-match-p (rx "/" string-end) url)
+        url
+      (concat url "/"))))
 
 
 (defvar *jenkins-jobs-list*


### PR DESCRIPTION
If `jenkins-url` has the value `http://example.com/foo`, we need to
enforce a trailing / when forming API URLs.