### PR TITLE
add Rebuild Last option

### DIFF
--- a/jenkins.el
+++ b/jenkins.el
@@ -42,6 +42,7 @@
 (defvar jenkins-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "b") 'jenkins--call-build-job-from-main-screen)
+    (define-key map (kbd "r") 'jenkins--call-rebuild-job-from-main-screen)
     (define-key map (kbd "v") 'jenkins--visit-job-from-main-screen)
     (define-key map (kbd "RET") 'jenkins-enter-job)
     map)
@@ -52,6 +53,7 @@
     (define-key keymap (kbd "1") 'jenkins-job-details-toggle)
     (define-key keymap (kbd "g") 'jenkins--refresh-job-from-job-screen)
     (define-key keymap (kbd "b") 'jenkins--call-build-job-from-job-screen)
+    (define-key keymap (kbd "r") 'jenkins--call-rebuild-job-from-job-screen)
     (define-key keymap (kbd "v") 'jenkins--visit-job-from-job-screen)
     (define-key keymap (kbd "$") 'jenkins--show-console-output-from-job-screen)
     keymap)
@@ -421,6 +423,15 @@
       (with-current-buffer (url-retrieve-synchronously build-url)
         (message (format "Building %s job started!" jobname))))))
 
+(defun jenkins-job-call-rebuild (jobname)
+  "Call jenkins build JOBNAME function."
+  (let ((url-request-extra-headers (jenkins--get-auth-headers))
+        (url-request-method "GET")
+        (build-url (format "%sjob/%s/lastCompletedBuild/rebuild/" (get-jenkins-url) jobname)))
+    (when (y-or-n-p (format "Ready to rebuild %s?" jobname))
+      (with-current-buffer (url-retrieve-synchronously build-url)
+        (message (format "Building %s job started!" jobname))))))
+
 (defun jenkins--call-build-job-from-main-screen ()
   "Build job from main screen."
   (interactive)
@@ -430,6 +441,16 @@
   "Call building job from job details in jenkins."
   (interactive)
   (jenkins-job-call-build jenkins-local-jobname))
+
+(defun jenkins--call-rebuild-job-from-main-screen ()
+  "rebuild job from main screen."
+  (interactive)
+  (jenkins-job-call-rebuild (tabulated-list-get-id)))
+
+(defun jenkins--call-rebuild-job-from-job-screen ()
+  "Call rebuilding job from job details in jenkins."
+  (interactive)
+  (jenkins-job-call-rebuild jenkins-local-jobname))
 
 (defun jenkins--refresh-job-from-job-screen ()
   "Refresh the current job"
@@ -476,6 +497,8 @@
                    builds)))))
      "\nBuild now! "
      (propertize ";; (press b to Build)\n" 'font-lock-face 'italic)
+     "Rebuild last run! "
+     (propertize ";; (press r to Rebuild)\n" 'font-lock-face 'italic)
      "View job's page "
      (propertize ";; (press v to open browser)\n" 'font-lock-face 'italic)
      )))


### PR DESCRIPTION
Allows the possibility of Rebuild the last build for a Jenkins job. 
It is available by using the 'r' shortcut key in both main screen and job screen.
It can be useful when having the Rebuild Plugin installed in Jenkins and the **Rebuild without asking for parameters** option checked.